### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/noaaweb/noaaweb.py
+++ b/noaaweb/noaaweb.py
@@ -39,7 +39,7 @@ def get_content(uri, string_log=None):
     root = None
     while (True):
         time.sleep(1)
-        if string_log != None:
+        if string_log is not None:
             print string_log + uri
         resource = urllib2.urlopen(uri, timeout=500).read()
         root = ET.fromstring(resource)
@@ -62,7 +62,7 @@ def get_GHCND(zipcode, year, month, day, token):
         zipcode, year, month, day, token)
     root = get_content(uri, "GHCND uri: ")
 
-    if root.get('pageCount') != None:
+    if root.get('pageCount') is not None:
         page_count = int(root.get('pageCount'))
         data = root.findall(".//*[date='%s-%s-%sT00:00:00.000']" % (year, month, day))
         for i in range(2, page_count + 1):

--- a/zip2wd/zip2wd.py
+++ b/zip2wd/zip2wd.py
@@ -131,14 +131,14 @@ def getStations(options):
 def sortStations(zipcode, r, stations):
     """Returns sorted stations list by distance
     """
-    if r == None:
+    if r is None:
         print("WARNING: zipcode = %s not found" % (zipcode))
         return None
     lat1 = r[3]
-    if lat1 == None:
+    if lat1 is None:
         lat1 = r[1]
     lon1 = r[4]
-    if lon1 == None:
+    if lon1 is None:
         lon1 = r[2]
     if lat1 == '' or lon1 == '':
         print("WARNING: not lat/lon for zipcode = %s" % (zipcode))
@@ -151,7 +151,7 @@ def sortStations(zipcode, r, stations):
         id = s[1]
         name = s[2]
         type = s[5]
-        if s[3] == None or s[4] == None: continue
+        if s[3] is None or s[4] is None: continue
         lat2 = float(s[3])
         lon2 = float(s[4])
         try:
@@ -211,7 +211,7 @@ def main(options, args):
 
     options.maxdays += 1
     
-    if out_extended != None and out_extended != options.extended:
+    if out_extended is not None and out_extended != options.extended:
         print("ERROR: Input/Output files in different format")
         sys.exit(-1)
     
@@ -263,13 +263,13 @@ def main(options, args):
             r = c.fetchone()
             if options.zip2ws:
                 dist = []
-                if r != None:
+                if r is not None:
                     c.execute("select distance, id, s.type, s.name, s.lat, s.lon from closest c join stations s on c.sid = s.rowid where c.zid = ? order by c.distance", (r[5],))
                     for r in c:
                         dist.append((int(r[0]), r[1], r[2], r[3], r[4], r[5]))
             else:
                 dist = sortStations(zipcode, r, stations)
-            if dist == None or len(dist) == 0:
+            if dist is None or len(dist) == 0:
                 writeResultRow(writer, row)
                 continue
             while True:
@@ -281,10 +281,10 @@ def main(options, args):
                 nth = 0
                 for s in dist:
                     nth += 1
-                    if options.closest != None and nth > options.closest:
+                    if options.closest is not None and nth > options.closest:
                         print("WARNING: N-th station > %d" % options.closest)
                         break
-                    if options.distance != None and (s[0] > options.distance * 1000):
+                    if options.distance is not None and (s[0] > options.distance * 1000):
                         print("WARNING: Distance > %d km" % options.distance)
                         break
                     values['nth'] = nth
@@ -414,7 +414,7 @@ if __name__ == "__main__":
         print("Please specific input file")
     else:
         options.inputfile = args[1]
-        if options.closest == None and options.distance == None:
+        if options.closest is None and options.distance is None:
             options.zip2ws = True
         main(options, args)
         

--- a/zip2ws/zip2ws.py
+++ b/zip2ws/zip2ws.py
@@ -277,7 +277,7 @@ def updateLatLonByGeocoding(options):
         lon = r[3]
         gc = getLatLonByZip(zip)
         print("Geocoding API ('%s') ==> %s" % (zip, str(gc)))
-        if gc == None:
+        if gc is None:
             print("WARNING: No Lat/Lon data for zip: %s (Google)" % (zip))
             continue
         gm_lat = gc[0]
@@ -302,7 +302,7 @@ def sortedStationsDistance(lat, lon, stations):
         sid = s[0]
         id = s[1]
         name = s[2]
-        if s[3] == None or s[4] == None: continue
+        if s[3] is None or s[4] is None: continue
         #print s[3], s[4]
         lat2 = float(s[3])
         lon2 = float(s[4])
@@ -323,7 +323,7 @@ def updateClosestStations(options):
     
     c.execute("select max(zid) from closest")
     r = c.fetchone()
-    if r[0] == None:
+    if r[0] is None:
         last_zid = 0
     else:
         last_zid = r[0]
@@ -348,7 +348,7 @@ def updateClosestStations(options):
         else:
             gm_lat = r[4]
             gm_lon = r[5]
-        if gm_lat != None and gm_lon != None:
+        if gm_lat is not None and gm_lon is not None:
             lat1 = gm_lat
             lon1 = gm_lon
         elif lat != '' and lon != '':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:get-weather-data?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:soodoku:get-weather-data?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
